### PR TITLE
Updated debase gem version and fixed test crash on ruby 2.6 env

### DIFF
--- a/overwrite_files/Gemfile.local
+++ b/overwrite_files/Gemfile.local
@@ -9,6 +9,8 @@ gem 'activeresource'
 gem 'timecop'
 if Gem.ruby_version < Gem::Version.new('3.1.0')
   gem 'ruby-debug-ide'
-  gem 'debase'
+  gem 'debase', '~> 0.2.5beta2'
 end
-gem 'debug'
+if Gem.ruby_version >= Gem::Version.new('2.7.0')
+  gem 'debug'
+end


### PR DESCRIPTION
@ishikawa999 (CC: @juno-nishizaki)  
`debug` gemですが、Ruby 2.6環境だと、行番号付きのテスト実行時にクラッシュが発生するようでした。
- [行番号付きのテスト実行時にクラッシュする · Issue #3 · redmine-patch-meetup/redmine_development_docker](https://github.com/redmine-patch-meetup/redmine_development_docker/issues/3)

Ruby 2.7以上の場合のみ、 `debug` gemをインストールし、合わせて `debase` gemもRuby 2.7で正しく動作するよう、更新しましたので、お手すきの際に確認頂けると助かります。 🙇‍♂️ 
- https://github.com/ruby-debug/debase/issues/88#issuecomment-758621787