### PR TITLE
Configurable Redmine Git URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-GIT_URL=https://github.com/redmine/redmine.git
+REPOSITORY_URL=https://github.com/redmine/redmine.git
 APP_NAME=Redmine
 APP_PORT=8000
 SELENIUM_PORT_1=4444

--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+GIT_URL=https://github.com/redmine/redmine.git
 APP_NAME=Redmine
 APP_PORT=8000
 SELENIUM_PORT_1=4444

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ $ cd ./redmine_development_docker
 * .envを書き換える
 
 ```bash
+# RedmineのリポジトリのURL。後から変えることも可能
+GIT_URL=https://github.com/redmine/redmine.git
 # VSCodeで表示する名前。バージョンごとに作るときは変えた方が良いかも
 APP_NAME=Redmine
 # 開発中のRedmineに http://localhost:8000 でアクセス出来るようになる。8000を既に使っている場合は変える
@@ -74,6 +76,8 @@ $ git remote set-url origin <リポジトリのURL>
 $ git fetch origin
 $ git reset --hard origin/master
 ```
+
+もしくは、コンテナから出て.envのGIT_URLを変更してからupdate_devcontainer_setting.shを再実行
 
 ### VSCodeの拡張機能を増やしたい
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ cd ./redmine_development_docker
 
 ```bash
 # RedmineのリポジトリのURL。後から変えることも可能
-GIT_URL=https://github.com/redmine/redmine.git
+REPOSITORY_URL=https://github.com/redmine/redmine.git
 # VSCodeで表示する名前。バージョンごとに作るときは変えた方が良いかも
 APP_NAME=Redmine
 # 開発中のRedmineに http://localhost:8000 でアクセス出来るようになる。8000を既に使っている場合は変える
@@ -77,7 +77,7 @@ $ git fetch origin
 $ git reset --hard origin/master
 ```
 
-もしくは、コンテナから出て.envのGIT_URLを変更してからupdate_devcontainer_setting.shを再実行
+もしくは、コンテナから出て.envのREPOSITORY_URLを変更してから既存のappディレクトリを削除し、update_devcontainer_setting.shを再実行
 
 ### VSCodeの拡張機能を増やしたい
 

--- a/update_devcontainer_setting.sh
+++ b/update_devcontainer_setting.sh
@@ -11,7 +11,7 @@ if [ ! -d app ]; then
     [ `which apt` ] && sudo apt-get update && sudo apt-get install git
     [ `which apk` ] && apk add git
   fi
-  git clone --config=core.autocflf=input https://github.com/redmine/redmine.git app
+  git clone --config=core.autocflf=input ${GIT_URL} app
   cp overwrite_files/Gemfile.local app/Gemfile.local
   cp overwrite_files/database.yml app/config/database.yml
   cp overwrite_files/configuration.yml app/config/configuration.yml

--- a/update_devcontainer_setting.sh
+++ b/update_devcontainer_setting.sh
@@ -11,7 +11,7 @@ if [ ! -d app ]; then
     [ `which apt` ] && sudo apt-get update && sudo apt-get install git
     [ `which apk` ] && apk add git
   fi
-  git clone --config=core.autocflf=input ${GIT_URL} app
+  git clone --config=core.autocflf=input ${REPOSITORY_URL} app
   cp overwrite_files/Gemfile.local app/Gemfile.local
   cp overwrite_files/database.yml app/config/database.yml
   cp overwrite_files/configuration.yml app/config/configuration.yml


### PR DESCRIPTION
@ishikawa999 (CC: @juno-nishizaki, @matobaa)  
Redmineパッチ会の方でフォークした [リポジトリ](https://github.com/redmine-patch-meetup/redmine_development_docker) について、最終的に変更差分がRedmineのGitのURLのみになったため、GitのURLをパラメータ化できればフォークしたリポジトリが不要になりそうに思いました...。🙇‍♂️ 💦 
- 変更差分: https://github.com/redmine-patch-meetup/redmine_development_docker/compare/master..develop

現状のREADME.mdに、リポジトリの変更手順について既に記載されていますので、若干オーバーな対応かもしれませんが、お手すきの際にご確認頂けますと幸いです。🙇‍♂️ 