### PR TITLE
Configurable Redmine Git branch

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 REPOSITORY_URL=https://github.com/redmine/redmine.git
+REPOSITORY_BRANCH=
 APP_NAME=Redmine
 APP_PORT=8000
 SELENIUM_PORT_1=4444

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ $ cd ./redmine_development_docker
 ```bash
 # RedmineのリポジトリのURL。後から変えることも可能
 REPOSITORY_URL=https://github.com/redmine/redmine.git
+# リポジトリのブランチ名。
+REPOSITORY_BRANCH=
 # VSCodeで表示する名前。バージョンごとに作るときは変えた方が良いかも
 APP_NAME=Redmine
 # 開発中のRedmineに http://localhost:8000 でアクセス出来るようになる。8000を既に使っている場合は変える

--- a/update_devcontainer_setting.sh
+++ b/update_devcontainer_setting.sh
@@ -11,7 +11,11 @@ if [ ! -d app ]; then
     [ `which apt` ] && sudo apt-get update && sudo apt-get install git
     [ `which apk` ] && apk add git
   fi
-  git clone --config=core.autocflf=input ${REPOSITORY_URL} app
+  if [ -z "${REPOSITORY_BRANCH}" ]; then
+    git clone --config=core.autocflf=input ${REPOSITORY_URL} app
+  else 
+    git clone --config=core.autocflf=input -b ${REPOSITORY_BRANCH} ${REPOSITORY_URL} app
+  fi
   cp overwrite_files/Gemfile.local app/Gemfile.local
   cp overwrite_files/database.yml app/config/database.yml
   cp overwrite_files/configuration.yml app/config/configuration.yml


### PR DESCRIPTION
#11 に類似しますが、古い Redmine でテストしたい場合等への対応として Git のブランチ名を `.env` ファイルで指定可能にしてみました。
ご検討お願いいたします。