### PR TITLE
Use 'VSCode rdbg Ruby Debugger' extension instead of deprecated 'Ruby' one

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "workspaceFolder": "/var/lib/redmine",
     "shutdownAction": "stopCompose",
     "extensions": [
-        "rebornix.ruby",
+        "KoichiSasada.vscode-rdbg",
         "eamodio.gitlens",
         "kaiwood.endwise",
         "mtxr.sqltools",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ SELENIUM_PORT_2=5900
 # Redmineから送信したメールを http://localhost:1080 で確認出来るようになる。1080を既に使っている場合は変える
 MAILCATCHER_PORT=1080
 # 開発するRedmineの推奨Rubyバージョンに応じて変える
-RUBY_VERSION=2.6
+RUBY_VERSION=2.7
 # mysqlやsqlite3に変えても良い。mysqlの場合、docker-compose.ymlのMySQL関連のコメントアウトを外す
 RAILS_DB_ADAPTER=postgresql
 ```

--- a/overwrite_files/.vscode/launch.json
+++ b/overwrite_files/.vscode/launch.json
@@ -2,12 +2,25 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "type": "rdbg",
             "name": "Rails server",
-            "type": "Ruby",
             "request": "launch",
             "cwd": "${workspaceRoot}",
-            "program": "${workspaceRoot}/bin/rails",
-            "args": ["server", "-b", "0"]
-        }
+            "script": "${workspaceRoot}/bin/rails server ",
+            "args": ["-b", "0"],
+            "askParameters": false,
+            "useBundler": false
+        },
+        {
+            "type": "rdbg",
+            "name": "Rails test",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "script": "${workspaceRoot}/bin/rails test",
+            "args": [
+            ],
+            "askParameters": false,
+            "useBundler": false
+        },
     ]
 }

--- a/overwrite_files/Gemfile.local
+++ b/overwrite_files/Gemfile.local
@@ -7,10 +7,6 @@ gem 'parallel_tests'
 gem 'benchmark-ips'
 gem 'activeresource'
 gem 'timecop'
-if Gem.ruby_version < Gem::Version.new('3.1.0')
-  gem 'ruby-debug-ide'
-  gem 'debase', '~> 0.2.5beta2'
-end
 if Gem.ruby_version >= Gem::Version.new('2.7.0')
   gem 'debug'
 end

--- a/update_devcontainer_setting.sh
+++ b/update_devcontainer_setting.sh
@@ -20,7 +20,7 @@ if [ ! -d app ]; then
   cp overwrite_files/database.yml app/config/database.yml
   cp overwrite_files/configuration.yml app/config/configuration.yml
   cp overwrite_files/additional_environment.rb app/config/additional_environment.rb
-  cp -r overwrite_files/.vscode app/.vscode
+  cp -r overwrite_files/.vscode app/
   echo 'appディレクトリにRedmineリポジトリをcloneしました'
 fi
 


### PR DESCRIPTION
以前、 #3, #6 で対応していた以下のVSCodeのデバッグ機能ですが、2023年10月頃から非推奨となっているようでした。
* [Ruby - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby)
* [VSCodeの`rebornix.ruby`から`shopify.ruby-lsp`に乗り換えるメモ - Madogiwa Blog](https://madogiwa0124.hatenablog.com/entry/2023/10/22/133354)

移行先はShopifyの以下の拡張機能が推奨となっていたものの、
* [Ruby LSP - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)

Ruby 2.7ではgem(`ruby-lsp`)をインストールできず、別フォルダを用意したりと少しややこしそうでしたので、
以下のデバッグ機能に特化した拡張機能に切り替えました。
* [VSCode rdbg Ruby Debugger - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg)

追加で、以下の修正も行ってますので、お手すきの際に確認頂けると助かります。 🙇
* `app/.vscode` フォルダが存在する状態で、 `cp -r overwrite_files/.vscode app/.vscode` を実行すると、 `app/.vscode/.vscode` フォルダが作成されないよう修正
* `README.md` 内の `RUBY_VERSION` を、 `.env` 内の値(`2.6`=>`2.7`)に変更